### PR TITLE
Add Jest tests for IBAN generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "devDependencies": {
     "tailwindcss": "^4.1.5",
-    "tailwindcss-cli": "^0.1.2"
+    "tailwindcss-cli": "^0.1.2",
+    "jest": "^29.7.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",

--- a/src/iban.js
+++ b/src/iban.js
@@ -1,0 +1,22 @@
+function calculateCheckDigits(countryCode, bban) {
+  const rearranged = bban + countryCode + '00';
+  let converted = '';
+  for (const ch of rearranged) {
+    converted += isNaN(ch) ? (ch.toUpperCase().charCodeAt(0) - 55).toString() : ch;
+  }
+  const mod97 = BigInt(converted) % 97n;
+  return String(98n - mod97).padStart(2, '0');
+}
+
+function generateIban(bankCode) {
+  const paddedBankCode = bankCode.toString().padStart(2, '0');
+  const accountNumber = Array.from({ length: 18 }, () => Math.floor(Math.random() * 10)).join('');
+  const bban = paddedBankCode + accountNumber;
+  const checkDigits = calculateCheckDigits('SA', bban);
+  return 'SA' + checkDigits + bban;
+}
+
+module.exports = {
+  calculateCheckDigits,
+  generateIban
+};

--- a/tests/iban.test.js
+++ b/tests/iban.test.js
@@ -1,0 +1,18 @@
+const { calculateCheckDigits, generateIban } = require('../src/iban');
+
+describe('calculateCheckDigits', () => {
+  test('returns correct digits for known BBAN examples', () => {
+    const bban1 = '80000000608010167519';
+    const bban2 = '20000001234567891234';
+    expect(calculateCheckDigits('SA', bban1)).toBe('03');
+    expect(calculateCheckDigits('SA', bban2)).toBe('44');
+  });
+});
+
+describe('generateIban', () => {
+  test('produces a valid Saudi IBAN string', () => {
+    const iban = generateIban('80');
+    expect(iban).toMatch(/^SA\d{22}$/);
+    expect(iban.slice(4,6)).toBe('80'); // bank code
+  });
+});


### PR DESCRIPTION
## Summary
- add `jest` as a dev dependency and use it for `npm test`
- create `src/iban.js` with reusable IBAN helpers
- test check digit calculation and format of generated IBANs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd984d63c832a8ca3702712b05e55