### PR TITLE
Add generateCard helper and tests

### DIFF
--- a/src/creditCard.js
+++ b/src/creditCard.js
@@ -31,7 +31,31 @@ function generateVisaNumber() {
   return digits.join('');
 }
 
+function generateCard(storage) {
+  const number = generateVisaNumber();
+
+  const now = new Date();
+  const startMonth = now.getFullYear() * 12 + now.getMonth();
+  const endMonth = startMonth + 60;
+  const randMonth = Math.floor(Math.random() * (endMonth - startMonth + 1)) + startMonth;
+  const year = Math.floor(randMonth / 12);
+  const month = randMonth % 12;
+  const expiry = String(month + 1).padStart(2, '0') + '/' + String(year % 100).padStart(2, '0');
+
+  const cvv = Math.floor(100 + Math.random() * 900);
+  const card = { number, expiry, cvv };
+
+  if (storage && typeof storage.getItem === 'function' && typeof storage.setItem === 'function') {
+    const history = JSON.parse(storage.getItem('cardHistory') || '[]');
+    history.unshift({ number, expiry, cvv });
+    storage.setItem('cardHistory', JSON.stringify(history.slice(0, 10)));
+  }
+
+  return card;
+}
+
 module.exports = {
   luhnCheck,
   generateVisaNumber,
+  generateCard,
 };

--- a/tests/creditCard.test.js
+++ b/tests/creditCard.test.js
@@ -1,9 +1,39 @@
-const { luhnCheck, generateVisaNumber } = require('../src/creditCard');
+const { luhnCheck, generateVisaNumber, generateCard } = require('../src/creditCard');
 
 describe('generateVisaNumber', () => {
   test('generates a 16-digit Visa card number that passes Luhn', () => {
     const card = generateVisaNumber();
     expect(card).toMatch(/^4\d{15}$/);
     expect(luhnCheck(card)).toBe(true);
+  });
+});
+
+describe('generateCard', () => {
+  test('returns card object with valid Luhn number and formatted expiry', () => {
+    const card = generateCard();
+    expect(card.number).toMatch(/^4\d{15}$/);
+    expect(luhnCheck(card.number)).toBe(true);
+    expect(card.expiry).toMatch(/^\d{2}\/\d{2}$/);
+    expect(String(card.cvv)).toMatch(/^\d{3}$/);
+  });
+
+  test('stores generated cards in localStorage history', () => {
+    const mockStorage = (() => {
+      let store = {};
+      return {
+        getItem: key => store[key] || null,
+        setItem: (key, val) => { store[key] = val; },
+      };
+    })();
+
+    for (let i = 0; i < 12; i++) {
+      generateCard(mockStorage);
+    }
+
+    const history = JSON.parse(mockStorage.getItem('cardHistory'));
+    expect(history).toHaveLength(10);
+    expect(history[0]).toHaveProperty('number');
+    expect(history[0]).toHaveProperty('expiry');
+    expect(luhnCheck(history[0].number)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- extend credit card module with `generateCard` helper
- test credit card generation features including history storage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e14d4d770832aa497c10706ae63f7