### PR TITLE
Share credit card helper with browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ Or just open `public/index.html` directly.
 
 ---
 
+## 🧪 Testing & Bundling
+
+Run `npm test` to execute the Jest suite. Helper modules in `src/` are CommonJS files used primarily for these tests.
+
+To make the credit card generator available in the browser, run `npm run build`. This bundles `src/creditCard.js` to `public/creditCard.js` and exposes a global `CreditCard` object.
+
+---
+
 ## 🤝 Contributing
 
 Contributions are welcome! If you have suggestions, improvements, or bug fixes, please fork the repo and open a pull request.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "jest": "^29.7.0"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "build": "node scripts/bundleCreditCard.js"
   },
   "repository": {
     "type": "git",

--- a/public/creditCard.js
+++ b/public/creditCard.js
@@ -1,0 +1,37 @@
+(function(global){
+function luhnCheck(number) {
+  const digits = number.split('').map(d => parseInt(d, 10));
+  let sum = 0;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let digit = digits[i];
+    if ((digits.length - i) % 2 === 0) {
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+    sum += digit;
+  }
+  return sum % 10 === 0;
+}
+
+function generateVisaNumber() {
+  let digits = [4];
+  for (let i = 1; i < 15; i++) {
+    digits[i] = Math.floor(Math.random() * 10);
+  }
+  let sum = 0;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let digit = digits[i];
+    if ((digits.length - i) % 2 === 1) { // because check digit not yet appended
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+    sum += digit;
+  }
+  const checkDigit = (10 - (sum % 10)) % 10;
+  digits.push(checkDigit);
+  return digits.join('');
+}
+
+
+  global.CreditCard = { luhnCheck, generateVisaNumber };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,7 @@
     };
   </script>
   <script src="https://unpkg.com/alpinejs@3.13.10/dist/cdn.min.js" defer></script>
+  <script src="creditCard.js"></script>
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2280%22>🇸🇦</text></svg>">
   <style>
     @keyframes spinHalf { 0% { transform: rotate(0deg); } 100% { transform: rotate(180deg); } }
@@ -554,29 +555,13 @@
           }
         },
 
-        luhnDigit(baseDigits) {
-          const digits = baseDigits.split('').map(d => parseInt(d, 10)).reverse();
-          let sum = 0;
-          for (let i = 0; i < digits.length; i++) {
-            let n = digits[i];
-            if (i % 2 === 0) {
-              n *= 2;
-              if (n > 9) n -= 9;
-            }
-            sum += n;
-          }
-          return (10 - (sum % 10)) % 10;
-        },
 
-        generateCard() {
-          if (this.generating) return;
-          this.generating = true;
-          setTimeout(() => {
-            try {
-              let base = '4';
-              for (let i = 1; i < 15; i++) base += Math.floor(Math.random() * 10);
-              const check = this.luhnDigit(base);
-              const number = base + check;
+          generateCard() {
+            if (this.generating) return;
+            this.generating = true;
+            setTimeout(() => {
+              try {
+                const number = window.CreditCard.generateVisaNumber();
 
               const now = new Date();
               const startMonth = now.getFullYear() * 12 + now.getMonth();

--- a/scripts/bundleCreditCard.js
+++ b/scripts/bundleCreditCard.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcPath = path.join(__dirname, '..', 'src', 'creditCard.js');
+const destPath = path.join(__dirname, '..', 'public', 'creditCard.js');
+
+let content = fs.readFileSync(srcPath, 'utf8');
+// Remove CommonJS export line
+content = content.replace(/module\.exports\s*=\s*\{[\s\S]*?\};?\n?/m, '');
+
+const bundle = `(function(global){\n${content}\n  global.CreditCard = { luhnCheck, generateVisaNumber };\n})(typeof window !== 'undefined' ? window : globalThis);\n`;
+
+fs.writeFileSync(destPath, bundle);
+console.log('Bundled credit card helper to', destPath);


### PR DESCRIPTION
## Summary
- bundle `src/creditCard.js` for the browser
- use bundled `CreditCard.generateVisaNumber()` in UI
- add build script and docs for running it

## Testing
- `npm run build`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e14d109c8832aa3033807e1ea9bbd